### PR TITLE
Introducing acceptancy tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ images/upload
 
 liquibase.properties
 !liquibase/*
+!web-tests/liquibase.properties
 
 # liquibase logs
 db-log

--- a/lib-tests/loggedIn.phpt
+++ b/lib-tests/loggedIn.phpt
@@ -1,20 +1,41 @@
 --TEST--
 test for loggedIn() library function
+--INI--
+session.gc_probability=0
+--COOKIE--
+PHPSESSID=user-session
 --FILE--
 <?php
 
-session_start(); 						// require sessions
-$_SESSION = array();
-require(__DIR__ . '/../web/functions.php'); 		// functions library being tested
+// functions library being tested
+require __DIR__ . '/../web/functions.php';
 
-/* IS signed in. */
-$_SESSION['uid'] = 1;
-echo 'User ', loggedIn() ? 'is' : 'is not', ' signed in.' . PHP_EOL;
+// loggedIn() needs an active session
+session_save_path(__DIR__ . '/../web-tests/session');
+session_start();
+
+$data = $_SESSION;
+
+
+/* test IS signed in. */
+test_translate(loggedIn());
+
+// sign out
+$_SESSION = array();
 
 /* Is NOT signed in. */
-$_SESSION['uid'] = NULL;
-echo 'User ', loggedIn() ? 'is' : 'is not', ' signed in.' . PHP_EOL;
+test_translate(loggedIn());
 
+
+// discard session changes!
+$_SESSION = $data;
+
+// helper
+function test_translate($bool) {
+	echo 'User ' . ($bool ? 'is' : 'is not') . " signed in.\n";
+}
+
+?>
 --EXPECT--
 User is signed in.
 User is not signed in.

--- a/lib-tests/loggedIn.phpt
+++ b/lib-tests/loggedIn.phpt
@@ -1,41 +1,41 @@
 --TEST--
-test for loggedIn() library function
+basic test for loggedIn() lib function
 --INI--
 session.gc_probability=0
---COOKIE--
-PHPSESSID=user-session
+assert.active=1
 --FILE--
 <?php
+
+// store session data locally
+session_save_path(__DIR__ . '/../web-tests/session');
+
+// loggedIn() needs an active session
+session_start();
+assert(session_decode('uid|i:1;username|s:5:"Kubis";'), 'failed to arrange testing session');
+
+// for reference
+printf("PHPSESSID=%s\n", session_id());
 
 // functions library being tested
 require __DIR__ . '/../web/functions.php';
 
-// loggedIn() needs an active session
-session_save_path(__DIR__ . '/../web-tests/session');
-session_start();
-
-$data = $_SESSION;
-
-
-/* test IS signed in. */
+/* should print: User is signed in. */
 test_translate(loggedIn());
 
 // sign out
 $_SESSION = array();
 
-/* Is NOT signed in. */
+/* should print: User is not signed in.*/
 test_translate(loggedIn());
 
 
-// discard session changes!
-$_SESSION = $data;
-
-// helper
+// helper function
 function test_translate($bool) {
 	echo 'User ' . ($bool ? 'is' : 'is not') . " signed in.\n";
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+PHPSESSID=%s
 User is signed in.
 User is not signed in.

--- a/lib-tests/recordLog.phpt
+++ b/lib-tests/recordLog.phpt
@@ -11,9 +11,7 @@ const TEST_LOG_SECTION = 'dummy-sect';
 define('TEST_LOG_DIR', __DIR__ . '/logs');
 
 var_dump(recordLog('Launching at port XX...', 'notice', TEST_LOG_SECTION, TEST_LOG_DIR));
-sleep(2);
 var_dump(recordLog('Running' . "\nadditional information not logged", 'status', TEST_LOG_SECTION, TEST_LOG_DIR));
-sleep(7);
 var_dump(recordLog('Internal at xXX crashed', 'fatal error', TEST_LOG_SECTION, TEST_LOG_DIR));
 var_dump(recordLog('Stopped', 'status', TEST_LOG_SECTION, TEST_LOG_DIR));
 

--- a/test-data.sql
+++ b/test-data.sql
@@ -11,15 +11,15 @@ use skdiggyshelper;
 -- Some mysterious users
 --changeset Kubo2:users-data-1
 INSERT INTO `users` (
-	`username`, `password`, `registerdate`, `email`, `description`
+	`id`, `username`, `password`, `registerdate`, `email`, `description`
 ) VALUES (
-	'Kubo2', MD5('heslo123'), NOW(), 'kelerest123@gmail.com', 'Spoluzakladateľ projektu DH + softwarový manažér'
+	1, 'Kubo2', MD5('heslo123'), NOW(), 'kelerest123@gmail.com', 'Spoluzakladateľ projektu DH + softwarový manažér'
 ), (
-	'Administrátor', MD5('admin'), NOW(), 'admin@localhost', 'Administrátor diskusného fóra'
+	2, 'Administrátor', MD5('admin'), NOW(), 'admin@localhost', 'Administrátor diskusného fóra'
 ), (
-	'WladinQ', MD5('heslo'), NOW(), 'vladimir.jacko.ml@gmail.com', 'Zakladateľ DH'
+	3, 'WladinQ', MD5('heslo'), NOW(), 'vladimir.jacko.ml@gmail.com', 'Zakladateľ DH'
 ), (
-	'Example', MD5('example'), NOW(), 'example@example.com', NULL
+	4, 'Example', MD5('example'), NOW(), 'example@example.com', NULL
 );
 
 --rollback TRUNCATE TABLE `users`;

--- a/web-tests/bootstrap.php
+++ b/web-tests/bootstrap.php
@@ -40,6 +40,10 @@ if(!$dbContext->query('CREATE DATABASE `' . $dbContext->escape_string($dbDefault
 // will use liquibase.properties in the same directory
 $liquibase = escapeshellcmd(realpath(__DIR__ . '/../liquibase/liquibase.jar') . " --url=jdbc:mysql://{$dbDefaults['host']}/{$dbDefaults['name']} update");
 
+if((!$cwd = getcwd()) || !chdir(__DIR__)) {
+	failClean('change working directory', $dbCfg, $dbCfgOrig, $dbContext, $dbDefaults['name']);
+}
+
 if(substr(php_uname(), 0, 7) == 'Windows') {
 	$liquibase = strtr($liquibase, ['/' => '^/']);
 
@@ -53,13 +57,14 @@ if(substr(php_uname(), 0, 7) == 'Windows') {
 	$liquibaseOut = substr($liquibaseOut[0], 0, 27);
 }
 
+chdir($cwd);
 
 if(strcmp($liquibaseOut, 'Liquibase Update Successful') <> 0) {
-	failClean('database setup failed' . $liquibaseOut, $dbCfg, $dbCfgOrig, $dbContext, $dbDefaults['name']);
+	failClean('database setup failed: ' . $liquibaseOut, $dbCfg, $dbCfgOrig, $dbContext, $dbDefaults['name']);
 }
 
 
-unset($dbCfg, $dbCfgOrig, $dbDefaults, $dbContext, $liquibase, $liquibaseProc, $liquibaseOut);
+unset($dbCfg, $dbCfgOrig, $dbDefaults, $dbContext, $liquibase, $liquibaseProc, $liquibaseOut, $cwd);
 
 
 //

--- a/web-tests/bootstrap.php
+++ b/web-tests/bootstrap.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace dhTest;
+
+use mysqli;
+
+/**
+ * This script sets up the environment for testsite-testing.
+ *
+ * @author  Kubo2
+ */
+
+
+$dbCfg = __DIR__ . '/../web/.db.cfg';
+$dbCfgOrig = "$dbCfg.backup";
+
+if(is_file($dbCfgOrig)) {
+	failClean('impossible to backup .db.cfg, ' . basename($dbCfgOrig) . ' already exists');
+} elseif(!rename($dbCfg, $dbCfgOrig)) {
+	failClean('impossible to backup .db.cfg, rename() failed');
+}
+
+$dbDefaults = [
+	'host' => 'localhost',
+	'user' => 'dh_tester',
+	'password' => 'testing',
+	'name' => uniqid('dh_test_', TRUE)
+];
+
+if(!file_put_contents($dbCfg, '<?php return ' . var_export($dbDefaults, TRUE) . '?>')) {
+	failClean('impossible to write .db.cfg', $dbCfg, $dbCfgOrig);
+}
+
+$dbContext = new mysqli($dbDefaults['host'], $dbDefaults['user'], $dbDefaults['password']);
+
+if(!$dbContext->query('CREATE DATABASE `' . $dbContext->escape_string($dbDefaults['name']) . '`')) {
+	failClean('could not create a database', $dbCfg, $dbCfgOrig, $dbContext);
+}
+
+// will use liquibase.properties in the same directory
+$liquibase = escapeshellcmd(realpath(__DIR__ . '/../liquibase/liquibase.jar') . " --url=jdbc:mysql://{$dbDefaults['host']}/{$dbDefaults['name']} update");
+
+if(substr(php_uname(), 0, 7) == 'Windows') {
+	$liquibase = strtr($liquibase, ['/' => '^/']);
+
+	// this is a workaround as there's no way of spawning a subprocess on Windows without the absolute path
+	$liquibaseProc = popen("start /B C:\\ProgramData\\Oracle\\Java\\javapath\\java.exe -jar $liquibase 2>&1", 'r');
+	
+	$liquibaseOut = fgets($liquibaseProc, 28); // reads (length - 1) bytes
+	pclose($liquibaseProc);
+} else {
+	exec("java -jar $liquibase 2>&1", $liquibaseOut);
+	$liquibaseOut = substr($liquibaseOut[0], 0, 27);
+}
+
+
+if(strcmp($liquibaseOut, 'Liquibase Update Successful') <> 0) {
+	failClean('database setup failed' . $liquibaseOut, $dbCfg, $dbCfgOrig, $dbContext, $dbDefaults['name']);
+}
+
+
+unset($dbCfg, $dbCfgOrig, $dbDefaults, $dbContext, $liquibase, $liquibaseProc, $liquibaseOut);
+
+
+//
+// helpers
+//
+
+function failClean($reason, $dbCfg = NULL, $dbCfgBackup = NULL, $dbContext = NULL, $dbName = NULL) {
+	if($dbCfg && $dbCfgBackup) {
+		rename($dbCfgBackup, $dbCfg);
+	}
+
+	if($dbContext) {
+		if($dbName) {
+			$dbContext->query('DROP DATABASE IF EXISTS `' . $dbContext->escape_string($dbName) . '`');
+		}
+
+		$dbContext->close();
+	}
+
+	die("fail $reason");
+}

--- a/web-tests/cleanup.php
+++ b/web-tests/cleanup.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace dhTest;
+
+use mysqli;
+
+/**
+ * This script cleans up after testsite-testing.
+ *
+ * @author  Kubo2
+ */
+
+
+$dbCfg = __DIR__ . '/../web/.db.cfg';
+$dbCfgOrig = "$dbCfg.backup";
+
+// assume .db.cfg exists if the backup exists
+if(is_file($dbCfgOrig)) {
+	$dbDefaults = require $dbCfg;
+
+	$dbContext = new mysqli($dbDefaults['host'], $dbDefaults['user'], $dbDefaults['password']);
+	$dbContext->query('DROP DATABASE IF EXISTS `' . $dbContext->escape_string($dbDefaults['name']) . '`');
+
+	rename($dbCfgOrig, $dbCfg);
+}

--- a/web-tests/connect.phpt
+++ b/web-tests/connect.phpt
@@ -19,7 +19,7 @@ assert((bool) mysql_stat($dbContext), 'mysql_stat failed to return server info')
 
 ?>
 ok
---EXPECT--
-ok
 --CLEAN--
 <?php require __DIR__ . '/cleanup.php' ?>
+--EXPECT--
+ok

--- a/web-tests/connect.phpt
+++ b/web-tests/connect.phpt
@@ -1,0 +1,25 @@
+--TEST--
+basic connect.php functionality test
+--INI--
+assert.active=1
+--FILE--
+<?php
+
+require __DIR__ . '/bootstrap.php';
+
+
+$dbContext = require __DIR__ . '/../web/connect.php';
+
+assert(defined('DB_CONNECTED'), 'DB_CONNECTED has not been defined');
+assert(DB_CONNECTED === $dbContext, 'the value returned by connect.php is not the same as DB_CONNECTED'); // this would be really odd
+
+assert(is_resource($dbContext), 'the value returned by connect.php is not a resource');
+assert(get_resource_type($dbContext) === 'mysql link', 'the value returned by connect.php is not a mysql link');
+assert((bool) mysql_stat($dbContext), 'mysql_stat failed to return server info');
+
+?>
+ok
+--EXPECT--
+ok
+--CLEAN--
+<?php require __DIR__ . '/cleanup.php' ?>

--- a/web-tests/liquibase.properties
+++ b/web-tests/liquibase.properties
@@ -1,0 +1,5 @@
+driver: com.mysql.jdbc.Driver
+classpath: ../liquibase/lib/mysql-connector-java-5.1.21-bin.jar
+changeLogFile: ../database-state.xml
+username: dh_tester
+password: testing

--- a/web-tests/loginphp/basic.phpt
+++ b/web-tests/loginphp/basic.phpt
@@ -1,0 +1,32 @@
+--TEST--
+basic login.php functionality test
+--INI--
+assert.active=1
+--ENV--
+return '
+HTTP_REFERER=https://example.com/backlink
+SERVER_NAME=example.com
+REQUEST_URI=/login.php
+';
+--POST--
+username=Example&password=example
+--FILE--
+<?php
+
+require __DIR__ . '/../bootstrap.php';
+
+session_save_path(__DIR__ . '/../session');
+
+require __DIR__ . '/../../web/login.php'; // exit()s
+
+assert($_SESSION['username'] === 'Example', 'username needs to be set to Example in session');
+assert($_SESSION['uid'] === 4, 'uid needs to be 4 in session according to test-data.sql');
+
+?>
+--CLEAN--
+<?php sleep(5); require __DIR__ . '/../cleanup.php' ?>
+--EXPECTHEADERS--
+HTTP/1.1 303 See Other
+Location: https://example.com/backlink
+--EXPECT--
+Resource Has Been Moved To: https://example.com/backlink

--- a/web-tests/logout.phpt
+++ b/web-tests/logout.phpt
@@ -1,0 +1,17 @@
+--TEST--
+basic logout.php functionality test
+--INI--
+session.gc_probability=0
+--FILE--
+<?php
+
+session_save_path(__DIR__ . '/session');
+
+require __DIR__ . '/../web/logout.php';
+
+?>
+ok
+--EXPECTHEADERS--
+Location: index.php
+--EXPECT--
+ok

--- a/web-tests/session/.gitignore
+++ b/web-tests/session/.gitignore
@@ -2,3 +2,5 @@
 
 *
 !.gitignore
+!sess_adminUser
+!sess_memberUser

--- a/web-tests/session/.gitignore
+++ b/web-tests/session/.gitignore
@@ -1,0 +1,4 @@
+# testing sessions directory
+
+*
+!.gitignore

--- a/web-tests/session/sess_adminUser
+++ b/web-tests/session/sess_adminUser
@@ -1,0 +1,1 @@
+uid|i:1;username|s:5:"Kubo2";

--- a/web-tests/session/sess_memberUser
+++ b/web-tests/session/sess_memberUser
@@ -1,0 +1,1 @@
+uid|i:4;username|s:7:"Example";

--- a/web-tests/session/sess_user-session
+++ b/web-tests/session/sess_user-session
@@ -1,0 +1,1 @@
+uid|i:1;username|s:5:"Kubis";

--- a/web-tests/session/sess_user-session
+++ b/web-tests/session/sess_user-session
@@ -1,1 +1,0 @@
-uid|i:1;username|s:5:"Kubis";

--- a/web/login.php
+++ b/web/login.php
@@ -30,7 +30,7 @@ if(empty($_POST["username"])) goto presmerovanie;
 // samotný proces prihlasovania
 $errorMessage = "";
 if(!empty($_POST["password"])) {
-	if(!defined('DB_CONNECTED') && FALSE === require("./connect.php")) {
+	if(!defined('DB_CONNECTED') && FALSE === require __DIR__ . '/connect.php') {
 		$errorMessage = "Ospravedlňujeme sa Vám, no naša databáza je bohužiaľ na niekoľko minút nedostupná. Skúste sa prihlásiť opäť o niekoľko minút.";
 		goto login_errorpage;
 	}


### PR DESCRIPTION
This PR introduces the possibility of directly testing if a certain page request produces the desired results and output. We can check for the results directly in the database or in the filesystem, but every test case must be atomic / self-contained and therefore cleaning up any mess possibly produced (except for the database, which is setup and deleted automatically). We can simulate HTTP requests but we cannot preset headers unless we are using server-tests.php, which is not a part of this approach. Instead, we simulate headers by adding them ot the $_SERVER superglobal array.

We can use sessions but we either have to clean them up afterwards or if using the default ones, only use them for reading. session_encode() is encouraged to be used instead. Moreover, most of dhForum pages use database in some way, so it is encourage to begin the test with require __DIR__ . '/bootstrap.php'; and finish with require __DIR__ . '/cleanup.php'; in the --CLEAN-- section; but do not include the database unnecessarily, because its setup radically slows down the test execution, by upto 5-10 full seconds. Also, use of native assert() in tests is encourgaed, while it has to be specified explicitly in assert.active=1 ini option.

[Wiki](https://github.com/Kubo2/diggyshelper/wiki/Ako-testova%C5%A5-dh-Forum)
